### PR TITLE
fix: populate global_symbols.relationships in expt-convert

### DIFF
--- a/cmd/scip/convert.go
+++ b/cmd/scip/convert.go
@@ -420,12 +420,33 @@ func (c *Converter) insertEnclosingRangeData(symbolToID map[string]int64, occs [
 	return nil
 }
 
+// marshalRelationships serializes a symbol's relationships for the
+// global_symbols.relationships column, framed the same way Chunk.toDBFormat
+// frames chunks.occurrences: a zstd-compressed wrapper message rather than a
+// bare repeated field, so the blob stays self-describing.
+func (c *Converter) marshalRelationships(rels []*scip.Relationship) ([]byte, error) {
+	blob, err := proto.Marshal(&scip.SymbolInformation{Relationships: rels})
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize relationships: %w", err)
+	}
+
+	var buf bytes.Buffer
+	c.zstdWriter.Reset(&buf)
+	if _, err = c.zstdWriter.Write(blob); err != nil {
+		return nil, fmt.Errorf("compression error: %w", err)
+	}
+	if err = c.zstdWriter.Close(); err != nil {
+		return nil, fmt.Errorf("flushing encoder: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
 func (c *Converter) insertGlobalSymbols(symbol *scip.SymbolInformation) (symbolID int64, err error) {
 	documentation := strings.Join(symbol.Documentation, "\n")
 
 	insertStmt, err := c.conn.Prepare(
-		`INSERT INTO global_symbols (symbol, display_name, kind, documentation, enclosing_symbol)
-		VALUES (?, ?, ?, ?, ?)
+		`INSERT INTO global_symbols (symbol, display_name, kind, documentation, enclosing_symbol, relationships)
+		VALUES (?, ?, ?, ?, ?, ?)
 		ON CONFLICT(symbol) DO NOTHING
 		RETURNING id`)
 	if err != nil {
@@ -452,6 +473,19 @@ func (c *Converter) insertGlobalSymbols(symbol *scip.SymbolInformation) (symbolI
 		insertStmt.BindNull(5)
 	} else {
 		insertStmt.BindText(5, symbol.EnclosingSymbol)
+	}
+	// Bind NULL rather than an empty frame when there are no relationships:
+	// insertGlobalSymbols is also called with synthetic SymbolInformation
+	// values carrying only a Symbol, and a compressed empty message would make
+	// "no relationships" indistinguishable from "present but empty".
+	if len(symbol.Relationships) == 0 {
+		insertStmt.BindNull(6)
+	} else {
+		relationshipsBlob, err := c.marshalRelationships(symbol.Relationships)
+		if err != nil {
+			return 0, err
+		}
+		insertStmt.BindBytes(6, relationshipsBlob)
 	}
 
 	if _, err = insertStmt.Step(); err != nil {

--- a/cmd/scip/convert_test.go
+++ b/cmd/scip/convert_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"zombiezen.com/go/sqlite"
 	"zombiezen.com/go/sqlite/sqlitex"
 
@@ -40,6 +41,7 @@ func TestConvert_SmokeTest(t *testing.T) {
 		{"documents", checkDocuments},
 		{"symbols", checkSymbols},
 		{"occurrences", checkOccurrences},
+		{"relationships", checkRelationships},
 	}
 
 	for _, check := range checks {
@@ -51,15 +53,24 @@ func TestConvert_SmokeTest(t *testing.T) {
 
 func testIndex1() *scip.Index {
 	pkg1S1Sym := "scip-go go . . pkg1/S1#"
+	pkg1I1Sym := "scip-go go . . pkg1/I1#"
 	return &scip.Index{
 		Documents: []*scip.Document{
 			{
 				RelativePath: "a.go",
 				Occurrences: []*scip.Occurrence{
 					{Symbol: pkg1S1Sym, Range: []int32{10, 3, 6}, SymbolRoles: int32(scip.SymbolRole_Definition)},
+					{Symbol: pkg1I1Sym, Range: []int32{20, 3, 6}, SymbolRoles: int32(scip.SymbolRole_Definition)},
 				},
 				Symbols: []*scip.SymbolInformation{
-					{Symbol: pkg1S1Sym},
+					// S1 implements I1 — exercises the relationships column.
+					{
+						Symbol: pkg1S1Sym,
+						Relationships: []*scip.Relationship{
+							{Symbol: pkg1I1Sym, IsImplementation: true},
+						},
+					},
+					{Symbol: pkg1I1Sym},
 				},
 			},
 			{
@@ -172,4 +183,74 @@ type occurrenceData struct {
 	Symbol       string
 	Role         int32
 	Range        scip.Range
+}
+
+// checkRelationships asserts SymbolInformation.relationships survives the
+// round-trip into global_symbols.relationships, and that symbols without
+// relationships store NULL rather than a compressed empty message. The column
+// is declared in the schema, so a converter that never writes it yields a
+// database that queries cleanly while reporting every symbol as having no
+// relationships.
+func checkRelationships(t *testing.T, index *scip.Index, db *sqlite.Conn) {
+	expected := map[string][]*scip.Relationship{}
+	for _, doc := range index.Documents {
+		for _, sym := range doc.Symbols {
+			if len(sym.Relationships) > 0 {
+				expected[sym.Symbol] = sym.Relationships
+			}
+		}
+	}
+	require.NotEmpty(t, expected, "fixture must exercise at least one relationship")
+
+	decoder, err := zstd.NewReader(nil)
+	require.NoError(t, err)
+	defer decoder.Close()
+
+	found := map[string][]*scip.Relationship{}
+	query := "SELECT symbol, relationships FROM global_symbols WHERE relationships IS NOT NULL"
+	err = sqlitex.ExecuteTransient(db, query, &sqlitex.ExecOptions{
+		ResultFunc: func(stmt *sqlite.Stmt) error {
+			symbol := stmt.ColumnText(0)
+			blob := make([]byte, stmt.ColumnLen(1))
+			stmt.ColumnBytes(1, blob)
+
+			raw, err := decoder.DecodeAll(blob, nil)
+			if err != nil {
+				return err
+			}
+			var info scip.SymbolInformation
+			if err := proto.Unmarshal(raw, &info); err != nil {
+				return err
+			}
+			found[symbol] = info.Relationships
+			return nil
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, found, len(expected))
+	for symbol, want := range expected {
+		got, ok := found[symbol]
+		require.True(t, ok, "no relationships stored for %s", symbol)
+		require.Len(t, got, len(want))
+		for i := range want {
+			require.Equal(t, want[i].Symbol, got[i].Symbol)
+			require.Equal(t, want[i].IsImplementation, got[i].IsImplementation)
+		}
+	}
+
+	// Symbols carrying no relationships must be NULL, not an empty frame:
+	// insertGlobalSymbols is also called with synthetic SymbolInformation
+	// values that only have a Symbol.
+	var nullCount int
+	err = sqlitex.ExecuteTransient(db,
+		"SELECT COUNT(*) FROM global_symbols WHERE relationships IS NULL",
+		&sqlitex.ExecOptions{
+			ResultFunc: func(stmt *sqlite.Stmt) error {
+				nullCount = stmt.ColumnInt(0)
+				return nil
+			},
+		})
+	require.NoError(t, err)
+	require.Greater(t, nullCount, 0, "symbols without relationships must store NULL")
 }


### PR DESCRIPTION
Fixes the `relationships` half of #464: `global_symbols.relationships` is declared in the `expt-convert` schema but never written, so it is `NULL` for every row in every generated database.

Because the column exists and queries against it succeed, the omission is silently lossy — a consumer cannot distinguish "this symbol has no relationships" from "the converter never stored any." `relationships` is the only source for implementation and type-definition edges, so type-hierarchy features built on the SQLite output cannot work at all, and the failure is easy to misattribute to the language indexer that produced the `.scip`.

## Change

`insertGlobalSymbols()` now serializes `SymbolInformation.relationships` into the existing column. The blob is framed exactly like `chunks.occurrences` in `Chunk.toDBFormat` — a zstd-compressed `proto.Marshal` of a wrapper message (`SymbolInformation` here, `Document` there) — so the encoding stays consistent within the file and remains self-describing.

Symbols with no relationships bind SQL `NULL` rather than a compressed empty message. That matters because `insertGlobalSymbols` is also called with synthetic `&scip.SymbolInformation{Symbol: occ.Symbol}` values for occurrence-only symbols; storing an empty frame for those would make "absent" and "present but empty" indistinguishable.

No schema change and no `scip.proto` change, so no regenerated bindings.

## Testing

`TestConvert_SmokeTest`'s fixture gains a symbol with an `is_implementation` relationship, and a `checkRelationships` helper joins the existing table of checks. It decompresses and unmarshals the stored blob, asserts a full round-trip of the relationship data, and asserts that symbols without relationships store `NULL`. The subtest fails on `main` (`"map[]" should have 1 item(s), but has 0`) and passes with this change; the other subtests are unaffected.

Verified end-to-end on a real `scip-typescript` index of a class implementing an interface:

```
BEFORE (v0.9.0):  5 symbols, 0 with relationships
AFTER  (patched): 5 symbols, 2 with relationships
```

The stored edges match the example in `scip.proto`'s own `Relationship` documentation — `Dog#` → `Animal#` with `is_implementation`, and `Dog#sound()` → `Animal#sound()` with both `is_implementation` and `is_reference`.

I also decoded the blobs from an independent (non-Go) consumer that expects `zstd(SymbolInformation)` framing, and they read cleanly — which is some corroboration that this framing is what downstream readers of this schema already assume.

## Not included: `signature`

#464 also notes that `global_symbols.signature` is never populated. I left it alone deliberately: the column is named `signature`, but `SymbolInformation` has no such field — the nearest is `Signature signature_documentation = 7`. Mapping one onto the other looks like a maintainer decision rather than something to guess at here. Happy to add it in a follow-up, or in this PR, given a preference.
